### PR TITLE
Made muonCollection input mandatory for muon matching

### DIFF
--- a/libs/extensions/include/NanoEvent.hpp
+++ b/libs/extensions/include/NanoEvent.hpp
@@ -24,14 +24,14 @@ class NanoEvent {
 
   std::shared_ptr<Event> GetEvent() { return event; }
 
-  std::shared_ptr<PhysicsObjects> GetDRMatchedMuons(float matchingDeltaR = 0.1,
-                                                    std::shared_ptr<Collection<std::shared_ptr<PhysicsObject>>> muonCollection = nullptr);
+  std::shared_ptr<PhysicsObjects> GetDRMatchedMuons(std::shared_ptr<Collection<std::shared_ptr<PhysicsObject>>> muonCollection,
+                                                    float matchingDeltaR = 0.1);
   std::shared_ptr<PhysicsObjects> GetOuterDRMatchedMuons(
-      float matchingDeltaR = 0.1, std::shared_ptr<Collection<std::shared_ptr<PhysicsObject>>> muonCollection = nullptr);
+      std::shared_ptr<Collection<std::shared_ptr<PhysicsObject>>> muonCollection, float matchingDeltaR = 0.1);
   std::shared_ptr<PhysicsObjects> GetProximityDRMatchedMuons(
-      float matchingDeltaR = 0.1, std::shared_ptr<Collection<std::shared_ptr<PhysicsObject>>> muonCollection = nullptr);
+      std::shared_ptr<Collection<std::shared_ptr<PhysicsObject>>> muonCollection, float matchingDeltaR = 0.1);
   std::shared_ptr<PhysicsObjects> GetSegmentMatchedMuons(
-      float minMatchRatio = 2.0f / 3.0f, std::shared_ptr<Collection<std::shared_ptr<PhysicsObject>>> muonCollection = nullptr);
+      std::shared_ptr<Collection<std::shared_ptr<PhysicsObject>>> muonCollection, float minMatchRatio = 2.0f / 3.0f);
 
   std::shared_ptr<PhysicsObjects> GetAllMuonVerticesCollection();
   std::shared_ptr<PhysicsObjects> GetVerticesForMuons(std::shared_ptr<PhysicsObjects> muonCollection);

--- a/libs/extensions/src/NanoEvent.cpp
+++ b/libs/extensions/src/NanoEvent.cpp
@@ -12,14 +12,10 @@ TLorentzVector NanoEvent::GetMetFourVector() {
 
 float NanoEvent::GetMetPt() { return Get("MET_pt"); }
 
-shared_ptr<PhysicsObjects> NanoEvent::GetDRMatchedMuons(float matchingDeltaR,
-                                                        shared_ptr<Collection<shared_ptr<PhysicsObject>>> muonCollection) {
-  auto looseMuons = GetCollection("LooseMuons");
-  auto looseDSAMuons = GetCollection("LooseDSAMuons");
-  if (muonCollection != nullptr) {
-    looseMuons = GetPATMuonsFromCollection(muonCollection);
-    looseDSAMuons = GetDSAMuonsFromCollection(muonCollection);
-  }
+shared_ptr<PhysicsObjects> NanoEvent::GetDRMatchedMuons(shared_ptr<Collection<shared_ptr<PhysicsObject>>> muonCollection,
+                                                        float matchingDeltaR) {
+  auto looseMuons = GetPATMuonsFromCollection(muonCollection);
+  auto looseDSAMuons = GetDSAMuonsFromCollection(muonCollection);
 
   auto allMuons = make_shared<PhysicsObjects>();
   for (auto muon : *looseMuons) {
@@ -38,14 +34,10 @@ shared_ptr<PhysicsObjects> NanoEvent::GetDRMatchedMuons(float matchingDeltaR,
   return allMuons;
 }
 
-shared_ptr<PhysicsObjects> NanoEvent::GetOuterDRMatchedMuons(float matchingDeltaR,
-                                                             shared_ptr<Collection<shared_ptr<PhysicsObject>>> muonCollection) {
-  auto looseMuons = GetCollection("LooseMuons");
-  auto looseDSAMuons = GetCollection("LooseDSAMuons");
-  if (muonCollection != nullptr) {
-    looseMuons = GetPATMuonsFromCollection(muonCollection);
-    looseDSAMuons = GetDSAMuonsFromCollection(muonCollection);
-  }
+shared_ptr<PhysicsObjects> NanoEvent::GetOuterDRMatchedMuons(shared_ptr<Collection<shared_ptr<PhysicsObject>>> muonCollection,
+                                                             float matchingDeltaR) {
+  auto looseMuons = GetPATMuonsFromCollection(muonCollection);
+  auto looseDSAMuons = GetDSAMuonsFromCollection(muonCollection);
 
   auto allMuons = make_shared<PhysicsObjects>();
   for (auto muon : *looseMuons) {
@@ -62,14 +54,10 @@ shared_ptr<PhysicsObjects> NanoEvent::GetOuterDRMatchedMuons(float matchingDelta
   return allMuons;
 }
 
-shared_ptr<PhysicsObjects> NanoEvent::GetProximityDRMatchedMuons(float matchingDeltaR,
-                                                                 shared_ptr<Collection<shared_ptr<PhysicsObject>>> muonCollection) {
-  auto looseMuons = GetCollection("LooseMuons");
-  auto looseDSAMuons = GetCollection("LooseDSAMuons");
-  if (muonCollection != nullptr) {
-    looseMuons = GetPATMuonsFromCollection(muonCollection);
-    looseDSAMuons = GetDSAMuonsFromCollection(muonCollection);
-  }
+shared_ptr<PhysicsObjects> NanoEvent::GetProximityDRMatchedMuons(shared_ptr<Collection<shared_ptr<PhysicsObject>>> muonCollection,
+                                                                 float matchingDeltaR) {
+  auto looseMuons = GetPATMuonsFromCollection(muonCollection);
+  auto looseDSAMuons = GetDSAMuonsFromCollection(muonCollection);
 
   auto allMuons = make_shared<PhysicsObjects>();
   for (auto muon : *looseMuons) {
@@ -87,14 +75,10 @@ shared_ptr<PhysicsObjects> NanoEvent::GetProximityDRMatchedMuons(float matchingD
   return allMuons;
 }
 
-shared_ptr<PhysicsObjects> NanoEvent::GetSegmentMatchedMuons(float minMatchRatio,
-                                                             shared_ptr<Collection<shared_ptr<PhysicsObject>>> muonCollection) {
-  auto looseMuons = GetCollection("LooseMuons");
-  auto looseDSAMuons = GetCollection("LooseDSAMuons");
-  if (muonCollection != nullptr) {
-    looseMuons = GetPATMuonsFromCollection(muonCollection);
-    looseDSAMuons = GetDSAMuonsFromCollection(muonCollection);
-  }
+shared_ptr<PhysicsObjects> NanoEvent::GetSegmentMatchedMuons(shared_ptr<Collection<shared_ptr<PhysicsObject>>> muonCollection,
+                                                             float minMatchRatio) {
+  auto looseMuons = GetPATMuonsFromCollection(muonCollection);
+  auto looseDSAMuons = GetDSAMuonsFromCollection(muonCollection);
 
   auto allMuons = make_shared<PhysicsObjects>();
   for (auto muon : *looseMuons) {


### PR DESCRIPTION
For the Get*MatchedMuons functions I think the input muonCollection should be mandatory so it can't depend on our muon collection naming. The "LooseMuons" and "LooseDSAMuons" collections are defined in tea_ttalps at the moment. (And I want to change "LooseMuons" to "LoosePATMuons").