### PR TITLE
Fixed problem with initialDimuon in cutflow manager

### DIFF
--- a/apps/examples/submitter.py
+++ b/apps/examples/submitter.py
@@ -39,7 +39,7 @@ def get_args():
 
   parser.add_argument(
     "--max_materialize",
-    type=float,
+    type=int,
     default=5000,
     help="specifies an overall limit on the number of jobs that can be materialized in the condor_schedd at any one time"
   )

--- a/apps/examples/submitter.py
+++ b/apps/examples/submitter.py
@@ -36,6 +36,13 @@ def get_args():
     default=1.0,
     help="requested memory in GB"
   )
+
+  parser.add_argument(
+    "--max_materialize",
+    type=float,
+    default=5000,
+    help="specifies an overall limit on the number of jobs that can be materialized in the condor_schedd at any one time"
+  )
   
   parser.add_argument("--dry", action="store_true", default=False, help="dry run, without submitting to condor")
   
@@ -142,7 +149,7 @@ def main():
     if submission_system == SubmissionSystem.local:  
       submission_manager.run_locally()
     if submission_system == SubmissionSystem.condor:
-      submission_manager.run_condor(args.job_flavour, args.memory, args.resubmit_job, args.dry)
+      submission_manager.run_condor(args.job_flavour, args.memory, args.max_materialize, args.resubmit_job, args.dry)
   
   logger_print()
 

--- a/configs/examples/scale_factors_config.py
+++ b/configs/examples/scale_factors_config.py
@@ -29,7 +29,7 @@ scaleFactors = {
     "path": "../tea/jsonPOG/POG/MUO/2018_UL/muon_Z.json.gz",
     "type": "NUM_TrackerMuons_DEN_genTracks",
     "year": "2018_UL",
-    "ValType": "sf",
+    "ValType": "nominal",
   },
   
   # Muon ID
@@ -37,19 +37,19 @@ scaleFactors = {
     "path": "../tea/jsonPOG/POG/MUO/2018_UL/muon_Z.json.gz",
     "type": "NUM_LooseID_DEN_TrackerMuons", 
     "year": "2018_UL",
-    "ValType": "sf",
+    "ValType": "nominal",
   },
   "muonIDMedium": {
     "path": "../tea/jsonPOG/POG/MUO/2018_UL/muon_Z.json.gz",
     "type": "NUM_MediumID_DEN_TrackerMuons", 
     "year": "2018_UL",
-    "ValType": "sf",
+    "ValType": "nominal",
   },
   "muonIDTight": {
     "path": "../tea/jsonPOG/POG/MUO/2018_UL/muon_Z.json.gz",
     "type": "NUM_TightID_DEN_TrackerMuons", 
     "year": "2018_UL",
-    "ValType": "sf",
+    "ValType": "nominal",
   },
   "dsamuonID": {
     "path": "../tea/DSAMuonSF/2018_Z/NUM_DisplacedID_DEN_dSAMuons_abseta_pt_schemaV2.json.gz",
@@ -63,13 +63,13 @@ scaleFactors = {
     "path": "../tea/jsonPOG/POG/MUO/2018_UL/muon_Z.json.gz",
     "type": "NUM_LooseRelIso_DEN_LooseID",
     "year": "2018_UL",
-    "ValType": "sf",
+    "ValType": "nominal",
   },
   "muonIsoTight": {
     "path": "../tea/jsonPOG/POG/MUO/2018_UL/muon_Z.json.gz",
     "type": "NUM_TightRelIso_DEN_TightIDandIPCut",
     "year": "2018_UL",
-    "ValType": "sf",
+    "ValType": "nominal",
   },
   
   # Muon trigger

--- a/libs/core/include/ScaleFactorsManager.hpp
+++ b/libs/core/include/ScaleFactorsManager.hpp
@@ -23,6 +23,7 @@ class ScaleFactorsManager {
 
   float GetJetIDScaleFactor(std::string name, float eta, float pt);
   float GetMuonScaleFactor(std::string name, float eta, float pt);
+  float GetDSAMuonScaleFactor(std::string name, float eta, float pt);
   float GetMuonTriggerScaleFactor(std::string name, float eta, float pt);
   float GetBTagScaleFactor(std::string name, float eta, float pt);
 

--- a/libs/core/src/CutFlowManager.cpp
+++ b/libs/core/src/CutFlowManager.cpp
@@ -119,8 +119,12 @@ string CutFlowManager::GetFullCutName(string cutName, string collectionName) {
   vector<string> matchingFullCutNames;
   map<string, float> weights = collectionName=="" ? weightsAfterCuts : weightsAfterCollectionCuts[collectionName];
   for (auto &[existingCutName, sumOfWeights] : weights) {
-    if (existingCutName.find(cutName) != string::npos) {
-      matchingFullCutNames.push_back(existingCutName);
+    size_t underscorePos = existingCutName.find("_");
+    if (underscorePos != string::npos) {
+      string nameAfterUnderscore = existingCutName.substr(underscorePos + 1);
+      if (nameAfterUnderscore == cutName) {
+        matchingFullCutNames.push_back(existingCutName);
+      }
     }
   }
 

--- a/libs/core/src/ScaleFactorsManager.cpp
+++ b/libs/core/src/ScaleFactorsManager.cpp
@@ -79,6 +79,13 @@ float ScaleFactorsManager::GetMuonScaleFactor(string name, float eta, float pt) 
   return TryToEvaluate(corrections[name], {fabs(eta), pt, extraArgs["ValType"]});
 }
 
+float ScaleFactorsManager::GetDSAMuonScaleFactor(string name, float eta, float pt) {
+  if (!applyScaleFactors["muon"]) return 1.0;
+
+  auto extraArgs = correctionsExtraArgs[name];
+  return TryToEvaluate(corrections[name], {extraArgs["year"], fabs(eta), pt, extraArgs["ValType"]});
+}
+
 float ScaleFactorsManager::GetMuonTriggerScaleFactor(string name, float eta, float pt) {
   if (!applyScaleFactors["muonTrigger"]) return 1.0;
 

--- a/libs/extensions/src/NanoMuon.cpp
+++ b/libs/extensions/src/NanoMuon.cpp
@@ -21,8 +21,12 @@ float NanoMuon::GetScaleFactor(string nameID, string nameIso, string nameReco) {
   
   auto &scaleFactorsManager = ScaleFactorsManager::GetInstance();
   
-  if(isDSA()) nameID = "dsamuonID";
-  float idSF = scaleFactorsManager.GetMuonScaleFactor(nameID, fabs(GetEta()), GetPt());
+  float idSF = 1.0;
+  if(isDSA()) {
+    nameID = "dsamuonID";
+    idSF = scaleFactorsManager.GetDSAMuonScaleFactor(nameID, fabs(GetEta()), GetPt());
+  }
+  else idSF = scaleFactorsManager.GetMuonScaleFactor(nameID, fabs(GetEta()), GetPt());
   float isoSF = scaleFactorsManager.GetMuonScaleFactor(nameIso, fabs(GetEta()), GetPt());
   float recoSF = scaleFactorsManager.GetMuonScaleFactor(nameReco, fabs(GetEta()), GetPt());
   

--- a/pylibs/plotting/Histogram.py
+++ b/pylibs/plotting/Histogram.py
@@ -37,8 +37,12 @@ class Histogram:
   def load(self, input_file):
     self.hist = input_file.Get(self.name)
     
-    if self.hist is None or type(self.hist) is TObject:
+    if self.hist is None:
       warn(f"Could not find histogram: {self.name}")
+      return
+    
+    if not self.hist or type(self.hist) is TObject:
+      warn(f"Histogram: {self.name} is invalid or uninitialized")
       return
     
     self.entries = self.hist.GetEntries()
@@ -67,9 +71,12 @@ class Histogram:
       self.hist = new_histogram
     
   def isGood(self):
-    if self.hist is None or type(self.hist) is TObject:
+    if self.hist is None:
       warn(f"Could not find histogram: {self.name}")
-      return False
+      return
+    if not self.hist or type(self.hist) is TObject:
+      warn(f"Histogram: {self.name} is invalid or uninitialized")
+      return
     if self.hist.GetEntries() == 0:
       return False
     

--- a/pylibs/submitter/SubmissionManager.py
+++ b/pylibs/submitter/SubmissionManager.py
@@ -41,11 +41,12 @@ class SubmissionManager:
     else:
       error("SubmissionManager -- Unrecognized input/output option")
   
-  def run_condor(self, job_flavour, memory_request, resubmit_job, dry):
+  def run_condor(self, job_flavour, memory_request, materialize_max, resubmit_job, dry):
     info("Running on condor")
     
     self.job_flavour = job_flavour
     self.memory_request = memory_request
+    self.materialize_max = materialize_max
     self.resubmit_job = resubmit_job
     
 
@@ -275,6 +276,7 @@ class SubmissionManager:
     os.system(f"sed -i 's/<executable>/{condor_run_script_name_escaped}/g' {self.condor_config_name}")
     os.system(f"sed -i 's/<memory_request>/{self.memory_request}/g' {self.condor_config_name}")
     os.system(f"sed -i 's/<job_flavour>/{self.job_flavour}/g' {self.condor_config_name}")
+    os.system(f"sed -i 's/<materialize_max>/{self.materialize_max}/g' {self.condor_config_name}")
   
     if self.resubmit_job is not None:
       os.system(f"sed -i 's/$(ProcId)/{self.resubmit_job}/g' {self.condor_config_name}")

--- a/templates/condor_config.template.sub
+++ b/templates/condor_config.template.sub
@@ -9,6 +9,6 @@ log                   = log/$(ClusterId).log
 requirements 	        = (OpSysAndVer == "CentOS7" || OpSysAndVer == "RedHat9")
 request_memory        = <memory_request> GB
 +JobFlavour           = "<job_flavour>"
-max_materialize       = 5000
+max_materialize       = <materialize_max>
 
 queue <n_jobs>

--- a/templates/condor_config.template.sub
+++ b/templates/condor_config.template.sub
@@ -9,5 +9,6 @@ log                   = log/$(ClusterId).log
 requirements 	        = (OpSysAndVer == "CentOS7" || OpSysAndVer == "RedHat9")
 # request_memory        = 4 GB
 +JobFlavour           = "<job_flavour>"
+max_materialize       = 5000
 
 queue <n_jobs>


### PR DESCRIPTION
The cutflow manager didn't recognize the difference between "initial" and "initialDImuon" cut names, so now I'm comparing the cut name to the exact name after the "_" in the already registered cut names. 

I also had some problem when I didn't have a histogram but it wasn't handled so I added another option in Histogram.py. 

And I also included the max_materialize option I had in my condor template, but maybe this should also be an option like you did for request_memory?